### PR TITLE
fix: error self.context.table[token][chat_id]["verbosity"] = VVVV

### DIFF
--- a/classes/bot.py
+++ b/classes/bot.py
@@ -314,6 +314,7 @@ class Bot:
             else:
                 if token not in self.context.table:
                     self.context.table[token] = {}
+                    self.context.table[token][chat_id] = {}
                 self.context.table[token][chat_id]["verbosity"] = VVVV
                 self.context.write_table()
                 bot.edit_message_text(


### PR DESCRIPTION
in the process of adding a project through the bot button, we get an error:
2022-12-18 17:16:30,989 - ERROR - No error handlers are registered, logging exception.
Traceback (most recent call last):
  File "/home/copycat/.local/lib/python3.10/site-packages/telegram/ext/dispatcher.py", line 557, in process_update
    handler.handle_update(update, self, check, context)
  File "/home/copycat/.local/lib/python3.10/site-packages/telegram/ext/handler.py", line 199, in handle_update
    return self.callback(update, context)
  File "/opt/devops/project/idvp/devops/tg-bot/gitlab-webhook-telegram/classes/bot.py", line 317, in button
    self.context.table[token][chat_id]["verbosity"] = VVVV
KeyError: 534429144